### PR TITLE
Fix time delay problem

### DIFF
--- a/src/RTClib_CI.h
+++ b/src/RTClib_CI.h
@@ -5,7 +5,6 @@
 #if defined(MOCK_PINS_COUNT)
 
 #include <RTClib.h>
-#include <ctime>
 
 /**
  * Subclass one chip (the one used by the authors!).
@@ -20,10 +19,11 @@ public:
   boolean begin() { return true; }
   void adjust(const DateTime &dt) {
     isInitialized = true;
-    offset = dt.unixtime() - std::time(0);
+    offset = dt.unixtime() - millis() / 1000;
   }
   boolean initialized() { return isInitialized; }
-  static DateTime now() { return DateTime(std::time(0) + offset); }
+  // note that this tracks the arduino_ci mock delay, not real time
+  static DateTime now() { return DateTime(offset + millis() / 1000); }
   virtual String className() const { return "RTC_PCF8523_CI"; }
 };
 

--- a/test/PCF8523.cpp
+++ b/test/PCF8523.cpp
@@ -16,6 +16,11 @@ unittest(test) {
   DateTime dt2 = rtc.now();
   assertTrue(dt1.unixtime() <= dt2.unixtime());
   assertTrue(dt2.unixtime() <= dt1.unixtime() + 1);
+
+  delay(5000);
+  dt2 = rtc.now();
+  assertTrue(dt1.unixtime() + 4 <= dt2.unixtime());
+  assertTrue(dt2.unixtime() <= dt1.unixtime() + 6);
 }
 
 unittest_main()


### PR DESCRIPTION
Remove improper use of time structure and base `now()` on arduino_ci mock time.
